### PR TITLE
Run benchmarks as tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "223d62adc52d51669ae2ee19bdb8b7d9fd6fcd9c",
-          "version": "0.0.6"
+          "revision": "3d79b2b5a2e5af52c14e462044702ea7728f5770",
+          "version": "0.1.0"
         }
       },
       {
@@ -15,7 +15,7 @@
         "repositoryURL": "https://github.com/google/swift-benchmark",
         "state": {
           "branch": "master",
-          "revision": "8df987a2016cc86c72cb92abcec733243bd1beba",
+          "revision": "687068e9e7dae20a8c46e1e1a4d04c5873a7c373",
           "version": null
         }
       }

--- a/Package.swift
+++ b/Package.swift
@@ -42,9 +42,13 @@ let package = Package(
             name: "StructuralBenchmarks",
             dependencies: ["StructuralCore", "StructuralExamples", "Benchmark"],
             swiftSettings: optimize),
+        .target(
+            name: "StructuralBenchmarksMain",
+            dependencies: ["Benchmark", "StructuralBenchmarks"],
+            swiftSettings: optimize),
         .testTarget(
             name: "StructuralTests",
-            dependencies: ["StructuralCore", "StructuralExamples"],
+            dependencies: ["StructuralCore", "StructuralExamples", "StructuralBenchmarks"],
             swiftSettings: optimize),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This module includes benchmarks done using
 You can run benchmarks using the following command:
 
 ```
-$ swift run -c release StructuralBenchmarks
+$ swift run -c release StructuralBenchmarksMain
 ```
 
 An example output of the benchmark run can be found in [benchmark.results] file.

--- a/Sources/StructuralBenchmarks/Suites.swift
+++ b/Sources/StructuralBenchmarks/Suites.swift
@@ -1,0 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+
+public let suites = [
+    additiveBenchmarks,
+    customComparableBenchmarks,
+    customDebugStringBenchmarks,
+    customEquatableBenchmarks,
+    customHashableBenchmarks,
+    decodeJSONBenchmarks,
+    encodeJSONBenchmarks,
+    inplaceAddBenchmarks,
+    scaleByBenchmarks,
+]

--- a/Sources/StructuralBenchmarksMain/main.swift
+++ b/Sources/StructuralBenchmarksMain/main.swift
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+import StructuralBenchmarks
+
+Benchmark.main(StructuralBenchmarks.suites)

--- a/Tests/StructuralTests/BenchmarkTests.swift
+++ b/Tests/StructuralTests/BenchmarkTests.swift
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 import Benchmark
+import StructuralBenchmarks
+import XCTest
 
-Benchmark.main([
-    additiveBenchmarks,
-    customComparableBenchmarks,
-    customDebugStringBenchmarks,
-    customEquatableBenchmarks,
-    customHashableBenchmarks,
-    decodeJSONBenchmarks,
-    encodeJSONBenchmarks,
-    inplaceAddBenchmarks,
-    scaleByBenchmarks,
-])
+final class BenchmarkTests: XCTestCase {
+
+    // A single catch-all test for macOS.
+    func testBenchmarks() {
+        Benchmark.runTests(suites: StructuralBenchmarks.suites)
+    }
+
+    // A more fine-grain per-benchmark tests used outside of macOS.
+    static var allTests = Benchmark.makeTests(
+        BenchmarkTests.self, suites: StructuralBenchmarks.suites)
+}

--- a/Tests/StructuralTests/XCTestManifests.swift
+++ b/Tests/StructuralTests/XCTestManifests.swift
@@ -18,6 +18,7 @@ import XCTest
     public func allTests() -> [XCTestCaseEntry] {
         return [
             testCase(AdditiveTests.allTests),
+            testCase(BenchmarkTests.allTests),
             testCase(CustomComparableTests.allTests),
             testCase(CustomComparableTests.allTests),
             testCase(CustomDebugStringTests.allTests),


### PR DESCRIPTION
This change adds another test suite that runs all of our benchmarks as part of `swift test`.