### PR TITLE
Re-add `set` into `structuralRepresentation`.

### DIFF
--- a/Sources/StructuralCore/Structural.swift
+++ b/Sources/StructuralCore/Structural.swift
@@ -21,7 +21,7 @@ public protocol Structural {
     init(structuralRepresentation: StructuralRepresentation)
 
     /// A structural representation of `self`.
-    var structuralRepresentation: StructuralRepresentation { get }
+    var structuralRepresentation: StructuralRepresentation { get set }
 }
 
 /// Structural representation of a Swift struct.


### PR DESCRIPTION
Support for `set` was previously there, but was accidentally dropped in
417945f12.