### PR TITLE
Proposal: change structural representation to avoid StructuralEmpty.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This module includes benchmarks done using
 You can run benchmarks using the following command:
 
 ```
-$ swift run -c release StructuralBenchmarksMain
+$ swift run -c release -Xswiftc -cross-module-optimization StructuralBenchmarksMain
 ```
 
 An example output of the benchmark run can be found in [benchmark.results] file.

--- a/Sources/StructuralBenchmarks/SequentialTransformerBenchmarks.swift
+++ b/Sources/StructuralBenchmarks/SequentialTransformerBenchmarks.swift
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Benchmark
+import StructuralCore
+import StructuralExamples
+
+let sequentialTransformerBenchmarks = BenchmarkSuite(name: "SequentialTransformer") { suite in
+
+    for sequenceSize in [1, 10, 100, 1000, 10000, 100_000] {
+        suite.benchmark("swift lazy transform (count: \(sequenceSize))") {
+            let s = Array((0..<sequenceSize).lazy.map { $0 * 2 })
+            precondition(s.count == sequenceSize)
+        }
+    }
+
+    for sequenceSize in [1, 10, 100, 1000, 10000, 100_000] {
+        suite.benchmark("structural lazy transform (count: \(sequenceSize))") {
+            let s = Array((0..<sequenceSize).lazyTransform(SequentialDouble()))
+            precondition(s.count == sequenceSize)
+        }
+    }
+}

--- a/Sources/StructuralBenchmarks/Suites.swift
+++ b/Sources/StructuralBenchmarks/Suites.swift
@@ -24,4 +24,5 @@ public let suites = [
     encodeJSONBenchmarks,
     inplaceAddBenchmarks,
     scaleByBenchmarks,
+    sequentialTransformerBenchmarks,
 ]

--- a/Sources/StructuralExamples/SequentialTransformer.swift
+++ b/Sources/StructuralExamples/SequentialTransformer.swift
@@ -1,0 +1,225 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// This file contains an oversimplified implementation of a value-semantic alternative to closures
+/// and shows (in concert with the corresponding unit tests and benchmarks) the potential benefits.
+
+import StructuralCore
+
+/// An arbitrary, stateful transformation from `Input` to `Output` with value semantics.
+///
+/// You can think of SequentialTransformer as a way of building up simple data structures that are
+/// similar to closures, however instead adhere to value semantics and preserve static type
+/// information to enable inlining.
+///
+/// Useful applications of such a type might be in place of an escaping closure.
+public protocol SequentialTransformer {
+	/// The [domain](https://en.wikipedia.org/wiki/Domain_of_a_function) to the function represented
+	/// by `self`.
+	associatedtype Input
+	/// The [range](https://en.wikipedia.org/wiki/Range_of_a_function) of the function represented
+	/// by `self`.
+	associatedtype Output
+
+	/// Returns the result of applying the function represented by `self` to `i`.
+	mutating func callAsFunction(_ i: Input) -> Output
+}
+
+extension Sequence {
+	/// Returns a lazy transforming sequence, preserving type information of `transformation`.
+	public func lazyTransform<T: SequentialTransformer>(_ transformer: T) -> LazyTransformSequence<Self, T> {
+		LazyTransformSequence(u: self, t: transformer)
+	}
+
+	/// Returns a value that can be used to consume `self` exactly once, computing a result with
+	/// `transformer`.
+	public func lazyFold<T: SequentialTransformer>(_ transformer: T) -> LazyFoldingSequence<Self, T> {
+		LazyFoldingSequence(u: self, t: transformer)
+	}
+}
+
+public struct LazyTransformSequence<
+	Underlying: Sequence,
+	Transformer: SequentialTransformer
+>: Sequence where Transformer.Input == Underlying.Element {
+	public struct Iterator: IteratorProtocol {
+		fileprivate var u: Underlying.Iterator
+		fileprivate var t: Transformer
+
+		public mutating func next() -> Transformer.Output? {
+			guard let i = u.next() else { return nil }
+			return t(i)
+		}
+	}
+
+	public func makeIterator() -> Iterator {
+		Iterator(u: u.makeIterator(), t: t)
+	}
+
+	fileprivate let u: Underlying
+	fileprivate let t: Transformer
+}
+
+public struct LazyFoldingSequence<
+	Underlying: Sequence,
+	Transformer: SequentialTransformer
+> where Transformer.Input == Underlying.Element {
+
+	private var u: Underlying?
+	private var t: Transformer
+
+	fileprivate init(u: Underlying, t: Transformer) {
+		self.u = u
+		self.t = t
+	}
+
+	public var result: Transformer {
+		mutating get {
+			consume()
+			return t
+		}
+	}
+
+	public mutating func consume() {
+		if let u = u {
+			var itr = u.makeIterator()
+			while let n = itr.next() {
+				_ = t(n)
+			}
+			self.u = nil
+		}
+	}
+}
+
+// TODO: Implement a lazy consumer, lazy filter, etc.
+
+// Sugar.
+
+extension SequentialTransformer where Self: Structural, Self.StructuralRepresentation: SequentialTransformer, Input == Self.StructuralRepresentation.Input, Output == Self.StructuralRepresentation.Output {
+	public mutating func callAsFunction(_ i: Input) -> Output {
+		self.structuralRepresentation(i)
+	}
+}
+
+// Inductive cases
+
+extension StructuralProperty: SequentialTransformer where Value: SequentialTransformer {
+	public mutating func callAsFunction(_ i: Value.Input) -> Value.Output {
+		value(i)
+	}
+}
+
+extension StructuralCons: SequentialTransformer
+where Value: SequentialTransformer, Next: SequentialTransformer, Value.Output == Next.Input {
+	public mutating func callAsFunction(_ i: Value.Input) -> Next.Output {
+		let tmp = value(i)
+		return next(tmp)
+	}
+}
+
+extension StructuralStruct: SequentialTransformer where Properties: SequentialTransformer {
+	public mutating func callAsFunction(_ i: Properties.Input) -> Properties.Output {
+		properties(i)
+	}
+}
+
+// Base cases.
+
+// Below are some silly pre-written transformations that can be composed with structural generic
+// programming. 
+
+public struct Duplicate<Input>: SequentialTransformer {
+	public init() {}
+
+	public func callAsFunction(_ i: Input) -> (Input, Input) {
+		(i, i)
+	}
+}
+
+public struct Merge<Elem: AdditiveArithmetic>: SequentialTransformer {
+	public init() {}
+	public func callAsFunction(_ i: (Elem, Elem)) -> Elem {
+		i.0 + i.1
+	}
+}
+
+public struct ApplyFirst<Underlying: SequentialTransformer, Ignored>: SequentialTransformer {
+	var underlying: Underlying
+
+	public init(_ underlying: Underlying) {
+		self.underlying = underlying
+	}
+
+	public mutating func callAsFunction(_ i: (Underlying.Input, Ignored)) -> (Underlying.Output, Ignored) {
+		(underlying(i.0), i.1)
+	}
+}
+
+public struct EnumerateTransformer<PassThrough>: SequentialTransformer {
+	var counter = 0
+	public init() {}
+
+	public mutating func callAsFunction(_ i: PassThrough) -> (Int, PassThrough) {
+		let returnValue = (counter, i)
+		counter += 1
+		return returnValue
+	}
+}
+
+public struct SumTransformer: SequentialTransformer {
+	public private(set) var sum = 0
+	public init() {}
+	public mutating func callAsFunction(_ i: Int) -> Int {
+		sum += i
+		return sum
+	}
+}
+
+///// Examples of use of structural generic programming.    ///////////////////////////////////////
+
+/// An incredibly inefficient way of multiplying a value by 2.
+public struct SequentialDouble<Elem: AdditiveArithmetic>: Structural, SequentialTransformer {
+	var d = Duplicate<Elem>()
+	var m = Merge<Elem>()
+
+	public init() {}
+}
+
+// Generated by the compiler (eventually).
+extension SequentialDouble {
+	public typealias Input = Elem
+	public typealias Output = Elem
+
+	public typealias StructuralRepresentation =
+		StructuralStruct<
+			StructuralCons<StructuralProperty<Duplicate<Elem>>,
+							StructuralProperty<Merge<Elem>>>>
+
+	public init(structuralRepresentation: StructuralRepresentation) {
+		self.d = structuralRepresentation.properties.value.value
+		self.m = structuralRepresentation.properties.next.value
+	}
+
+	public var structuralRepresentation: StructuralRepresentation {
+		get {
+			return StructuralStruct(Self.self,
+				StructuralCons(StructuralProperty("d", d, isMutable: true),
+					StructuralProperty("m", m, isMutable: true)))
+		}
+		set {
+			self.d = newValue.properties.value.value
+			self.m = newValue.properties.next.value
+		}
+	}
+}

--- a/Tests/StructuralTests/SequentialTransformerTests.swift
+++ b/Tests/StructuralTests/SequentialTransformerTests.swift
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import StructuralExamples
+
+final class SequentialTransformerTests: XCTestCase {
+    func testLazyTransform() {
+        let seq = (0..<Int.max).lazyTransform(SequentialDouble()).prefix(10)
+        XCTAssertEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18], Array(seq))
+    }
+
+    func testLazyConsume() {
+        var lazySum = (0..<10).lazyTransform(SequentialDouble()).lazyFold(SumTransformer())
+        // TODO: Test to ensure the sequence is only traversed once!
+        XCTAssertEqual(90, lazySum.result.sum)
+        XCTAssertEqual(90, lazySum.result.sum)
+    }
+
+    static var allTests = [
+        ("testLazyTransform", testLazyTransform),
+        ("testLazyConsume", testLazyConsume),
+    ]
+}

--- a/Tests/StructuralTests/XCTestManifests.swift
+++ b/Tests/StructuralTests/XCTestManifests.swift
@@ -31,6 +31,7 @@ import XCTest
             testCase(EncodeJSONTests.allTests),
             testCase(InplaceAddTests.allTests),
             testCase(StructuralRepresentationTests.allTests),
+            testCase(SequentialTransformerTests.allTests),
         ]
     }
 #endif


### PR DESCRIPTION
This PR represents a proposal to change the way Swift types are encoded into their structural
representation to enable more flexible applications of structural generic programming. This proposal
was inspired by [a structural programming-based deep learning model composition
API](https://github.com/tensorflow/swift-models/pull/613).

> tl;dr: Drop the `StructuralEmpty` from the end of the field list.

Today, we represent a `struct` as a "Cons-list" of its fields, terminated by `StructuralEmpty`. For
example:

```swift
struct Point2: Structural {
	var x: Int
	var y: Float
}
```

would have the following `StructuralRepresentation` associated type generated by the compiler:

```swift
extension Point2 {
	public typealias StructuralRepresentation =
		StructuralStruct<
			StructuralCons<StructuralProperty<Int>,
			StructuralCons<StructuralProperty<Float>,
			StructuralEmpty>>>

	// ...
}
```

or, alternatively written with a made-up syntax loosely inspired by Scala's `HList` type:

```swift
typealias StructuralRepresentation =
  StructuralStruct<
  	StructuralProperty<Int> :: StructuralProperty<Float> :: StructuralEmpty>
```

This proposal suggests we modify the representation to look as follows:

```swift
extension Point2 {
	public typealias StructuralRepresentation =
		StructuralStruct<
			StructuralCons<StructuralProperty<Int>,
			StructuralCons<StructuralProperty<Float>>>>

	// ...
}
```

or in the made-up syntax:

```
typealias StructuralRepresentation =
  StructuralStruct<
  	StructuralProperty<Int> :: StructuralProperty<Float>>
```

The advantage of such a shift in representation are three fold:

1. **Simplifies common inductive cases**: when providing a structural generic programming-based
   automatic conformance, an extension for `StructuralEmpty` is required. In the examples in this
   repository, most of them are benign empty implementations (e.g. [`DecodeJSON`](https://github.com/google/swift-structural/blob/043713b88913efe79bc5041af5ba3de3c1d74517/Sources/StructuralExamples/DecodeJSON.swift#L61),
   [`DefaultInitializable`](https://github.com/google/swift-structural/blob/043713b88913efe79bc5041af5ba3de3c1d74517/Sources/StructuralExamples/DefaultInitializable.swift#L48),
   [`ScaleBy`](https://github.com/google/swift-structural/blob/043713b88913efe79bc5041af5ba3de3c1d74517/Sources/StructuralExamples/ScaleBy.swift#L85)),
   however some of them require more careful thought (e.g. [`CustomComparable`](https://github.com/google/swift-structural/blob/043713b88913efe79bc5041af5ba3de3c1d74517/Sources/StructuralExamples/CustomComparable.swift#L102)).

   With this change, only conformances that would like to support zero-sized types are required to
   provide a conformance for `StructuralEmpty`. (See below.)

 2. **Special handling for zero-sized types.** Some protocols might want to have distinct
   handling for zero-sized types. For example, when encoding JSON, different applications might want
   to alternatively serialize or not serialize the field. (For example, a sentinal marker field to
   declare a version.)

   If this proposal is adopted, the JSON library could drop the `StructuralEmpty` conformance to
   `StructuralEmpty`, which would automatically remove automatic `EncodeJSON` conformance for zero-
   sized types.

 3. **Composition of computation based on fields.**

The included motivating example is a way of preserving static information when performing lazy
operations to sequences. In Swift today, escaping closures are heap allocated and type erased, which
effectively forms an optimization boundary. Additionally, they operate with reference semantics
and cannot have any additional properties / fields (unlike classes or structs) and thus cannot have
additional entry points to access the state.

By representing the transformation not as a closure, but instead as a `struct`, we can realize
better performance, and build additonal entry points to view and manipulate the stored state. This
PR includes a _woefully incomplete_ step in this direction. See the tests for the usage, and the
benchmark numbers below for a comparison of performance. (tl;dr: At small sizes, the existing lazy
transforms are equivalent or faster; at large sizes, the completely unoptimized structural generic
programming implementation is about 2x faster.)

Neural networks can be thought of as differentiable functions with machine learned state.
Manipulating that state via value semantics works extremely well (as demonstrated by the existing
S4TF APIs). One additional important aspect of neural networks is a need to explicitly manipulate
the contained state (e.g. weight regularlization, resetting the learned parameters when doing
transfer learning). Being able to access that state explicitly with a convenient name is valuable
from an API ergonomic perspective.

Most neural network architectures are described as compositions of other "layers" (bottoming out in
a few common layer types, such as `Linear` (aka `Dense`), `Convolution`, and parameterless
nonlinearities such as `ReLu`). The most common form of composition is sequential composition.

By removing the `StructuralEmpty` "tail" of the HList of fields (and also extending structural
generic programming for differentiability), we can now begin to leverage the benefits of automatic
conformance implementations for this use case, such as sequential or parallel composition.

For example:

```swift
struct MyModel: Structural, StructuralLayer {
	var conv: Conv2D
	var flatten: Flatten
	var dense: Dense

	// The following explicit implementation becomes unnecessary with SGP.
	func callAsFunction(_ input: Tensor) -> Tensor {
		return dense(flatten(conv(input)))
	}
}
```

Because `StructuralEmpty` must define one and only one `associatedtype Input`, and because there are
many possible `Input` and `Output` types in neural networks (e.g. an Attention layer takes both a
key and query tensor), the presence of `StructuralEmpty` constrains the application of structural
generic programming.

There are other problems that have a similar flavor to neural networks. One can look at neural
networks through the lens of a program generating a graph of operations which are then executed with
as much parallelism as possible by a runtime. This lens can also be reapplied to a variety of other
applications, such as build systems. (e.g. Bazel has a Python-like syntax for build a graph, which
is then executed in parallel by the rest of the build system. The combination of CMake and Ninja
operates similarly. Hat-tip to clattner@.) In addition, the intermediate products of build systems
sometimes need to be named and explicitly referenced. (Perhaps the most sophisticated example of
this approach is [`sbt`](https://www.scala-sbt.org/).)

One of the non-obvious implications of this change is that it unlocks important use cases that would
not be well served by different approaches to metaprogramming. (The first usecase is conditional
conformances.)

Concretely, when representing a sequential composition of computations produced and consumed by
fields of a struct, a non-HList-style representation of the corresponding types forces the generic
code to type-cast all the way to `Any`. For example, in some hypothetical hyper-specializing
compiler that would specialize reflection from runtime to compile time, a sequential composition
operation would look as follows:

```
extension MyProtocol {
	public func callAsFunction(_ input: FirstField.Input) -> LastField.Output {
		var intermediateResult: Any = input
		for field in self.allFields {
		    intermediateResult = field(intermediateResult)
		}
		return intermediateResult as! LastField.Output
	}
}
```

Instead, structural generic programming represents the iteration as recursion where the type of the
carry variable is explicitly represented as an induction [type] variable, ensuring type safety (at
the cognitive cost of a recursive representation).

 - **Can we get rid of `StructuralEmpty`?** In order to handle zero-sized types, I think we must
   keep it around.
 - **What other applications can we derive from SGP thanks to this change?** Please feel free to
   suggest some more! ;-)

Performance numbers comparing the explicit closure-allocating lazy operations vs a structural-based
approach.

```
name                                                             time        std        iterations
--------------------------------------------------------------------------------------------------
SequentialTransformer: swift lazy transform (count: 1)              149.0 ns ± 201.72 %    1000000
SequentialTransformer: swift lazy transform (count: 10)             211.0 ns ±  87.56 %    1000000
SequentialTransformer: swift lazy transform (count: 100)            736.0 ns ±  87.69 %    1000000
SequentialTransformer: swift lazy transform (count: 1000)          5727.0 ns ±  18.60 %     251236
SequentialTransformer: swift lazy transform (count: 10000)        53680.0 ns ±  11.02 %      26456
SequentialTransformer: swift lazy transform (count: 100000)      538643.0 ns ±   6.06 %       2507
SequentialTransformer: structural lazy transform (count: 1)         151.0 ns ± 157.65 %    1000000
SequentialTransformer: structural lazy transform (count: 10)        758.0 ns ±  64.62 %    1000000
SequentialTransformer: structural lazy transform (count: 100)      1501.0 ns ±  34.70 %     907048
SequentialTransformer: structural lazy transform (count: 1000)     4562.0 ns ±  19.75 %     305737
SequentialTransformer: structural lazy transform (count: 10000)   31690.0 ns ±   8.86 %      48379
SequentialTransformer: structural lazy transform (count: 100000) 287372.0 ns ±  13.87 %       4826
```