### PR TITLE
Reduce some boilerplate without needing higher-kinded types.

### DIFF
--- a/Sources/StructuralCore/Forwardable.swift
+++ b/Sources/StructuralCore/Forwardable.swift
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A type that can be converted to and from its structural representation.
+public protocol Forwardable {
+    /// A structural representation for `Self`.
+    associatedtype Underlying
+
+    /// A structural representation of `self`.
+    var underlying: Underlying { get set }
+}
+
+extension StructuralStruct: Forwardable {
+    public typealias Underlying = Properties
+    public var underlying: Properties {
+        get { properties }
+        set { properties = newValue }
+    }
+}
+
+extension StructuralProperty: Forwardable {
+    public typealias Underlying = Value
+    public var underlying: Value {
+        get { value }
+        set { value = newValue }
+    }
+}
+
+extension StructuralEnum: Forwardable {
+    public typealias Underlying = Cases
+    public var underlying: Cases {
+        get { cases }
+        set { cases = newValue }
+    }
+}
+
+// TODO: StructuralCase?

--- a/Sources/StructuralExamples/CustomEquatable.swift
+++ b/Sources/StructuralExamples/CustomEquatable.swift
@@ -23,6 +23,14 @@ public protocol CustomEquatable {
 
 // Inductive cases.
 
+extension Forwardable where Underlying: CustomEquatable {
+    public func customEqual(_ other: Self) -> Bool {
+        return underlying.customEqual(other.underlying)
+    }
+}
+extension StructuralProperty: CustomEquatable where Value: CustomEquatable {}
+extension StructuralStruct: CustomEquatable where Properties: CustomEquatable {}
+
 extension StructuralCons: CustomEquatable
 where Value: CustomEquatable, Next: CustomEquatable {
     public func customEqual(_ other: Self) -> Bool {
@@ -51,13 +59,6 @@ where AssociatedValues: CustomEquatable {
     }
 }
 
-extension StructuralProperty: CustomEquatable
-where Value: CustomEquatable {
-    public func customEqual(_ other: Self) -> Bool {
-        return value.customEqual(other.value)
-    }
-}
-
 extension StructuralEnum: CustomEquatable
 where Cases: CustomEquatable {
     public func customEqual(_ other: Self) -> Bool {
@@ -65,15 +66,9 @@ where Cases: CustomEquatable {
     }
 }
 
-extension StructuralStruct: CustomEquatable
-where Properties: CustomEquatable {
-    public func customEqual(_ other: Self) -> Bool {
-        properties.customEqual(other.properties)
-    }
-}
-
 // Base cases.
 
+// This would go away with https://github.com/google/swift-structural/pull/5 (except for empty structs).
 extension StructuralEmpty: CustomEquatable {
     public func customEqual(_ other: StructuralEmpty) -> Bool {
         return true

--- a/Sources/StructuralExamples/CustomHashable.swift
+++ b/Sources/StructuralExamples/CustomHashable.swift
@@ -63,26 +63,15 @@ where RawValue: CustomHashable, AssociatedValues: CustomHashable {
     }
 }
 
-extension StructuralProperty: CustomHashable
-where Value: CustomHashable {
+extension Forwardable where Underlying: CustomHashable {
     public func customHash(into hasher: inout Hasher) {
-        value.customHash(into: &hasher)
+        underlying.customHash(into: &hasher)
     }
 }
 
-extension StructuralEnum: CustomHashable
-where Cases: CustomHashable {
-    public func customHash(into hasher: inout Hasher) {
-        cases.customHash(into: &hasher)
-    }
-}
-
-extension StructuralStruct: CustomHashable
-where Properties: CustomHashable {
-    public func customHash(into hasher: inout Hasher) {
-        properties.customHash(into: &hasher)
-    }
-}
+extension StructuralProperty: CustomHashable where Value: CustomHashable {}
+extension StructuralEnum: CustomHashable where Cases: CustomHashable {}
+extension StructuralStruct: CustomHashable where Properties: CustomHashable {}
 
 // Base cases.
 


### PR DESCRIPTION
Just a first pass. Note that this doesn't work for all the kinds of things you'd like to do with the structural protocols (e.g. `CustomDebugString`).