### PR TITLE
Proof-of-concept implementation of Static Structural

### DIFF
--- a/Sources/StructuralCore/Structural.swift
+++ b/Sources/StructuralCore/Structural.swift
@@ -12,6 +12,95 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// A type conforms to `Structural2` to enable compile-time reflection.
+///
+/// Structural generic programming is a powerful meta-programming technique
+/// for Swift. ...
+public protocol Structural2 {
+    /// The type of the static representation of `Self`.
+    associatedtype StaticStructuralRepresentation
+
+    /// An instance of the static structural representation of `Self`.
+    static var staticStructuralRepresentation: StaticStructuralRepresentation { get }
+
+    /// Creates a fresh instance of `Self` with minimal initialization.
+    init(_unsafeZero: Void)
+}
+
+public struct StaticStructuralStruct<BaseType, Properties> {
+    public let baseType: BaseType.Type
+    public let properties: Properties
+
+    public init(baseType: BaseType.Type, properties: Properties) {
+        self.baseType = baseType
+        self.properties = properties
+    }
+}
+
+public struct StaticStructuralProperty<BaseType, Value> {
+    public let keyPath: KeyPath<BaseType, Value>
+    public let name: String  // TODO: Get rid of this if KeyPath was made more powerful.
+    
+    public init(keyPath: KeyPath<BaseType, Value>, name: String) {
+        self.keyPath = keyPath
+        self.name = name
+    }
+
+    public var isMutable: Bool {
+        keyPath is WritableKeyPath<BaseType, Value>
+    }
+}
+
+public protocol _StructuralImpl {
+    associatedtype StructuralRepresentation
+    associatedtype BaseType
+
+    func project(_ instance: BaseType) -> StructuralRepresentation
+    func update(_ instance: inout BaseType, with representation: StructuralRepresentation)
+}
+
+extension StaticStructuralProperty: _StructuralImpl {
+    public typealias StructuralRepresentation = StructuralProperty<Value>
+
+    public func project(_ instance: BaseType) -> StructuralRepresentation {
+        StructuralProperty(name, instance[keyPath: keyPath],  isMutable: isMutable)
+    }
+
+    public func update(_ instance: inout BaseType, with representation: StructuralRepresentation) {
+        if let mutableKeyPath = keyPath as? WritableKeyPath<BaseType, Value> {
+            instance[keyPath: mutableKeyPath] = representation.value
+        }
+    }
+}
+
+extension StructuralCons: _StructuralImpl where Value: _StructuralImpl, Next: _StructuralImpl, Value.BaseType == Next.BaseType {
+    public typealias StructuralRepresentation = StructuralCons<Value.StructuralRepresentation, Next.StructuralRepresentation>
+    public typealias BaseType = Value.BaseType
+
+    public func project(_ instance: BaseType) -> StructuralRepresentation {
+        let v = value.project(instance)
+        let n = next.project(instance)
+        return StructuralRepresentation(v, n)
+    }
+
+    public func update(_ instance: inout BaseType, with representation: StructuralRepresentation) {
+        value.update(&instance, with: representation.value)
+        next.update(&instance, with: representation.next)
+    }
+}
+
+extension StaticStructuralStruct: _StructuralImpl where Properties: _StructuralImpl, Properties.BaseType == BaseType {
+    public typealias StructuralRepresentation = StructuralStruct<Properties.StructuralRepresentation>
+
+    public func project(_ instance: BaseType) -> StructuralRepresentation {
+        StructuralRepresentation(baseType, properties.project(instance))
+    }
+
+    public func update(_ instance: inout BaseType, with representation: StructuralRepresentation) {
+        properties.update(&instance, with: representation.properties)
+    }
+}
+
 /// A type that can be converted to and from its structural representation.
 public protocol Structural {
     /// A structural representation for `Self`.
@@ -22,6 +111,21 @@ public protocol Structural {
 
     /// A structural representation of `self`.
     var structuralRepresentation: StructuralRepresentation { get set }
+}
+
+extension Structural where Self: Structural2, StaticStructuralRepresentation: _StructuralImpl, StaticStructuralRepresentation.BaseType == Self, StructuralRepresentation == StaticStructuralRepresentation.StructuralRepresentation {
+    // Typealias inference doesn't work. :-(
+    // public typealias StructuralRepresentation = StaticStructuralRepresentation.StructuralRepresentation
+
+    public init(structuralRepresentation: StructuralRepresentation) {
+        self.init(_unsafeZero: ())
+        Self.staticStructuralRepresentation.update(&self, with: structuralRepresentation)
+    }
+
+    public var structuralRepresentation: StructuralRepresentation {
+        get { Self.staticStructuralRepresentation.project(self) }
+        set { Self.staticStructuralRepresentation.update(&self, with: newValue) }
+    }
 }
 
 /// Structural representation of a Swift struct.


### PR DESCRIPTION
Based on explorations of structural generic programming in
https://github.com/tensorflow/swift-models/pull/650 we would like to support
smooth interactions between KeyPaths and structural generic programming.
Based on discussions with @shabalind, I have put together a quick
proof-of-concept demonstrating how to unify a "static structural"
implementation with the "instance"-level structural generic programming we
have been exploring so far.

This is definitely an incomplete implementation, but this would allow us to
easily implement KeyPathIterable and its ilk on top of structural generic
programming (something not possible previously), in addition to unifying with
the existing KeyPath world.

There are a couple further extensions:

 1. **Solution for `HNil`** To use a proper cons-list construction, this will
    require a bottom type (`Never`) that conforms to every protocol, and
    multiple conformances. Alternatively, an encoding that appears to work
    is a cons-list construction that doesn't use a special end type.
 2. **Typealias inference**: Swift does not currently infer typealiases for
    these kinds of derived conformances.
 3. **Enum support** This current implementation doesn't include enum support
    although this is straight forward to add.
 4. **Simplier structural representations**: When the single static structural
    derived conformance, we can easily implement multiple simpler "structural"
    encodings (e.g. a simple Cons-list of values in addition to the current
    structural representation).
 5. Extensions to KeyPaths could enable StaticStructural to simply be the key
    paths themselves. (i.e. if you could retrieve the field name corresponding
    to the key path.)