### PR TITLE
Update documentation.

### DIFF
--- a/Sources/StructuralCore/Structural.swift
+++ b/Sources/StructuralCore/Structural.swift
@@ -12,7 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// A type that can be converted to and from its structural representation.
+/// Types that can be converted to and from their structural representations.
+///
+/// The compiler can synthesize conformances to the `Structural` protocol for
+/// `struct` and `enum` declarations.
+///
+/// For `struct` declarations, the canonical structural representation type is
+/// `StructuralStruct<...>`, whose generic parameter contains information
+/// representing all stored properties.
+///
+/// `struct` example:
+///
+///     struct StudentGrades {
+///         let classId: Int
+///         var grades: [Double]
+///     }
+///
+///     extension StudentGrades: Structural {
+///         typealias StructuralRepresentation = StructuralStruct<
+///             StructuralCons<
+///                 StructuralProperty<Int>,
+///                 StructuralCons<
+///                     StructuralProperty<[Double]>,
+///                     StructuralEmpty
+///                 >
+///             >
+///         >
+///     }
+///
+/// For `enum` declarations, the canonical structural representation type is
+/// `StructuralEnum<...>`, whose generic parameter contains information
+/// representing all enum cases and associated values.
+///
+/// `enum` example:
+///
+///     enum Color: Int {
+///         case red = 0xFF0000
+///         case green = 0x00FF00
+///         case blue = 0x0000FF
+///     }
+///
+///     extension Color: Structural {
+///         // Compiler synthesizes:
+///         typealias StructuralRepresentation =
+///             StructuralEnum<
+///                 StructuralEither<
+///                     StructuralCase<Int, StructuralEmpty>,
+///                     StructuralEither<
+///                         StructuralCase<Int, StructuralEmpty>,
+///                         StructuralCase<Int, StructuralEmpty>
+///                     >
+///                 >
+///             >
+///     }
+///
 public protocol Structural {
     /// A structural representation for `Self`.
     associatedtype StructuralRepresentation
@@ -21,103 +74,187 @@ public protocol Structural {
     init(structuralRepresentation: StructuralRepresentation)
 
     /// A structural representation of `self`.
-    var structuralRepresentation: StructuralRepresentation { get set }
+    var structuralRepresentation: StructuralRepresentation {
+        get set
+    }
 }
 
-/// Structural representation of a Swift struct.
+/// The structural representation of a Swift struct type.
+///
+/// `StructuralStruct<...>` is the compiler-synthesized
+/// `StructuralRepresentation` for structs conforming to `Structural`.
+///
+/// - Parameter Properties: a type representing the names and values of stored
+///   properties.
 public struct StructuralStruct<Properties> {
-    public var type: Any.Type?
-    public var properties: Properties
+    /// The type of the represented struct type.
+    public var representedType: Any.Type?
+    /// The names and values of stored properties.
+    public var body: Properties
 
-    public init(_ properties: Properties) {
-        self.type = nil
-        self.properties = properties
+    /// Creates a representation having the given body.
+    public init(_ body: Properties) {
+        self.representedType = nil
+        self.body = body
     }
 
-    public init(_ type: Any.Type, _ properties: Properties) {
-        self.type = type
-        self.properties = properties
+    /// Creates a representation for the given struct type, having the given body.
+    public init(_ representedType: Any.Type, _ body: Properties) {
+        self.representedType = representedType
+        self.body = body
     }
 }
 
-/// Structural representation of a Swift property.
+/// The structural representation of a Swift property or associated value.
+///
+/// `StructuralProperty<...>` is the compiler-synthesized
+/// `StructuralRepresentation` for a struct's stored property and an enum case's
+/// associated value.
+///
+/// - Parameter Value: the type of the represented property or associated value.
 public struct StructuralProperty<Value> {
-    public var name: StaticString
+    /// The name of the property or associated value.
+    public var name: String
+    /// The value of the property or associated.
     public var value: Value
+    /// The mutability of the property value.
     public var isMutable: Bool
 
+    /// Creates a representation from the given value.
     public init(_ value: Value) {
         self.name = ""
         self.value = value
         self.isMutable = false
     }
 
-    public init(_ name: StaticString, _ value: Value) {
+    /// Creates a representation from the given name and value.
+    public init(_ name: String, _ value: Value) {
         self.name = name
         self.value = value
         self.isMutable = false
     }
 
-    public init(_ name: StaticString, _ value: Value, isMutable: Bool) {
+    /// Creates a representation from the given name, value, and mutability.
+    public init(_ name: String, _ value: Value, isMutable: Bool) {
         self.name = name
         self.value = value
         self.isMutable = isMutable
     }
 }
 
-/// Structural representation of a Swift enum.
+/// The structural representation of a Swift enum type.
+///
+/// `StructuralEnum<...>` is the compiler-synthesized
+/// `StructuralRepresentation` for enums conforming to `Structural`.
+///
+/// - Parameter Cases: a type representing the names and values of associated
+///   values.
 public struct StructuralEnum<Cases> {
-    public var type: Any.Type?
-    public var cases: Cases
+    /// The type of the represented enum type.
+    public var representedType: Any.Type?
+    /// The names and values of associated values.
+    public var body: Cases
 
-    public init(_ cases: Cases) {
-        self.type = nil
-        self.cases = cases
+    /// Creates a representation having the given body.
+    public init(_ body: Cases) {
+        self.representedType = nil
+        self.body = body
     }
 
-    public init(_ type: Any.Type, _ cases: Cases) {
-        self.type = type
-        self.cases = cases
+    /// Creates a representation for the given enum type, having the given body.
+    public init(_ representedType: Any.Type, _ body: Cases) {
+        self.representedType = representedType
+        self.body = body
     }
 }
 
-/// Structural representation of a Swift enum case.
+/// The structural representation of a Swift enum case.
+///
+/// `StructuralCase<...>` is the compiler-synthesized
+/// `StructuralRepresentation` for cases of enums conforming to `Structural`.
+///
+/// - Parameter RawValue: the type of the raw value of the enum case.
+/// - Parameter AssociatedValues: the type representing the names and associated
+///   values of the enum case.
 public struct StructuralCase<RawValue, AssociatedValues> {
-    public var name: StaticString
+    /// The name of the enum case.
+    public var name: String
+    /// The raw value of the enum case.
     public var rawValue: RawValue
+    /// The names and associated values of the enum case.
     public var associatedValues: AssociatedValues
 
+    /// Creates a representation from the given raw value and associated values.
     public init(_ rawValue: RawValue, _ associatedValues: AssociatedValues) {
         self.name = ""
         self.rawValue = rawValue
         self.associatedValues = associatedValues
     }
 
-    public init(_ name: StaticString, _ rawValue: RawValue, _ associatedValues: AssociatedValues) {
+    /// Creates a representation from the given raw value and associated values.
+    public init(
+        _ name: String, _ rawValue: RawValue, _ associatedValues: AssociatedValues
+    ) {
         self.name = name
         self.rawValue = rawValue
         self.associatedValues = associatedValues
     }
 }
 
-/// Structural representation of a heterogeneous list cons cell.
+/// The structural representation of a chain of properties or associated values.
+///
+/// `StructuralCons<...>` is the compiler-synthesized
+/// `StructuralRepresentation` for chaining struct stored properties and enum
+/// case associated values.
+///
+/// - Parameter Value: the type of the first value.
+/// - Parameter Next: the type of the second value.
+///
+/// - Note: `StructuralCons<...>` is used as a type-level heterogeneous cons
+///   list, which is verbose and not particularly human-readable. If variadiac
+///   generics are added to the Swift language, `StructuralCons` can be
+///   deprecated in favor of a less-verbose heterogeneous list representaiton
+///   using variadic generics.
 public struct StructuralCons<Value, Next> {
+    /// The first value.
     public var value: Value
+    /// The next value.
     public var next: Next
 
+    /// Creates a representation from the given values.
     public init(_ value: Value, _ next: Next) {
         self.value = value
         self.next = next
     }
 }
 
-/// Structural representation of an empty heterogeneous list cons cell.
+/// The structural representation of an empty list.
+///
+/// - Note: `StructuralEmpty<...>` is used as the base case of the type-level
+///   heterogeneous cons list `StructuralCons`. If variadiac generics are added
+///   to the Swift language, `StructuralCons` can be deprecated in favor of a
+///   less-verbose heterogeneous list representation using variadic generics.
 public struct StructuralEmpty {
     public init() {}
 }
 
-/// Structural representation of an alternative between either Left or Right.
+/// The structural representation of an alternative between either `Left` or
+/// `Right`.
+///
+/// `StructuralEither<...>` is the compiler-synthesized
+/// `StructuralRepresentation` for chaining together enum cases.
+///
+/// - Parameter Left: the type of the first alternative.
+/// - Parameter Right: the type of the second alternative.
+///
+/// - Note: `StructuralEither<...>` is used as a type-level heterogeneous cons
+///   list, which is verbose and not particularly human-readable. If variadiac
+///   generics are added to the Swift language, `StructuralEither` can be
+///   deprecated in favor of a less-verbose heterogeneous list representaiton
+///   using variadic generics.
 public enum StructuralEither<Left, Right> {
+    /// The first alternative.
     case left(Left)
+    /// The second alternative.
     case right(Right)
 }

--- a/Sources/StructuralCore/Structural.swift
+++ b/Sources/StructuralCore/Structural.swift
@@ -211,10 +211,7 @@ public struct StructuralCase<RawValue, AssociatedValues> {
 /// - Parameter Next: the type of the second value.
 ///
 /// - Note: `StructuralCons<...>` is used as a type-level heterogeneous cons
-///   list, which is verbose and not particularly human-readable. If variadiac
-///   generics are added to the Swift language, `StructuralCons` can be
-///   deprecated in favor of a less-verbose heterogeneous list representaiton
-///   using variadic generics.
+///   list.
 public struct StructuralCons<Value, Next> {
     /// The first value.
     public var value: Value
@@ -231,9 +228,7 @@ public struct StructuralCons<Value, Next> {
 /// The structural representation of an empty list.
 ///
 /// - Note: `StructuralEmpty<...>` is used as the base case of the type-level
-///   heterogeneous cons list `StructuralCons`. If variadiac generics are added
-///   to the Swift language, `StructuralCons` can be deprecated in favor of a
-///   less-verbose heterogeneous list representation using variadic generics.
+///   heterogeneous cons list `StructuralCons`.
 public struct StructuralEmpty {
     public init() {}
 }

--- a/Sources/StructuralExamples/ASCII.swift
+++ b/Sources/StructuralExamples/ASCII.swift
@@ -51,8 +51,8 @@ extension ASCII: Structural {
             }
         }
         set {
-            assert(newValue.type == ASCII.self)
-            switch newValue.cases {
+            assert(newValue.representedType == ASCII.self)
+            switch newValue.body {
             case .left: self = .tab
             case .right(.left): self = .lineFeed
             case .right(.right): self = .carriageReturn
@@ -61,7 +61,7 @@ extension ASCII: Structural {
     }
 
     public init(structuralRepresentation repr: StructuralRepresentation) {
-        switch repr.cases {
+        switch repr.body {
         case .left(_):
             self = .tab
         case .right(.left(_)):

--- a/Sources/StructuralExamples/BinaryTree.swift
+++ b/Sources/StructuralExamples/BinaryTree.swift
@@ -45,11 +45,11 @@ extension BinaryTree: Structural {
         get {
             switch self {
             case let .leaf(x):
-                let properties = StructuralCons(StructuralProperty(x), StructuralEmpty())
+                let body = StructuralCons(StructuralProperty(x), StructuralEmpty())
                 return StructuralEnum(
-                    BinaryTree.self, .left(StructuralCase("leaf", 0, properties)))
+                    BinaryTree.self, .left(StructuralCase("leaf", 0, body)))
             case let .branch(left, value, right):
-                let properties =
+                let body =
                     StructuralCons(
                         StructuralProperty(left),
                         StructuralCons(
@@ -58,11 +58,11 @@ extension BinaryTree: Structural {
                                 StructuralProperty(right),
                                 StructuralEmpty())))
                 return StructuralEnum(
-                    BinaryTree.self, .right(StructuralCase("branch", 1, properties)))
+                    BinaryTree.self, .right(StructuralCase("branch", 1, body)))
             }
         }
         set {
-            switch newValue.cases {
+            switch newValue.body {
             case let .left(leafCase):
                 self = .leaf(leafCase.associatedValues.value.value)
             case let .right(branchCase):
@@ -75,7 +75,7 @@ extension BinaryTree: Structural {
     }
 
     public init(structuralRepresentation repr: StructuralRepresentation) {
-        switch repr.cases {
+        switch repr.body {
         case let .left(leafCase):
             self = .leaf(leafCase.associatedValues.value.value)
         case let .right(branchCase):

--- a/Sources/StructuralExamples/Color.swift
+++ b/Sources/StructuralExamples/Color.swift
@@ -51,8 +51,8 @@ extension Color: Structural {
             }
         }
         set {
-            assert(newValue.type == Color.self)
-            switch newValue.cases {
+            assert(newValue.representedType == Color.self)
+            switch newValue.body {
             case .left: self = .red
             case .right(.left): self = .green
             case .right(.right): self = .blue
@@ -61,7 +61,7 @@ extension Color: Structural {
     }
 
     public init(structuralRepresentation repr: StructuralRepresentation) {
-        switch repr.cases {
+        switch repr.body {
         case .left(_):
             self = .red
         case .right(.left(_)):

--- a/Sources/StructuralExamples/MyAdditive.swift
+++ b/Sources/StructuralExamples/MyAdditive.swift
@@ -60,13 +60,13 @@ where Value: MyAdditive {
 
 extension StructuralStruct: MyAdditive where Properties: MyAdditive {
     public static func + (lhs: Self, rhs: Self) -> Self {
-        return StructuralStruct(lhs.properties + rhs.properties)
+        return StructuralStruct(lhs.body + rhs.body)
     }
 }
 
 extension StructuralEnum: MyAdditive where Cases: MyAdditive {
     public static func + (lhs: Self, rhs: Self) -> Self {
-        return StructuralEnum(lhs.cases + rhs.cases)
+        return StructuralEnum(lhs.body + rhs.body)
     }
 }
 

--- a/Sources/StructuralExamples/MyComparable.swift
+++ b/Sources/StructuralExamples/MyComparable.swift
@@ -62,19 +62,19 @@ where Value: MyComparable, Next: MyComparable {
 extension StructuralStruct: MyComparable
 where Properties: MyComparable {
     public func less(_ other: Self) -> Bool {
-        return properties.less(other.properties)
+        return body.less(other.body)
     }
 
     public func lessOrEqual(_ other: Self) -> Bool {
-        return properties.lessOrEqual(other.properties)
+        return body.lessOrEqual(other.body)
     }
 
     public func greater(_ other: Self) -> Bool {
-        return properties.greater(other.properties)
+        return body.greater(other.body)
     }
 
     public func greaterOrEqual(_ other: Self) -> Bool {
-        return properties.greaterOrEqual(other.properties)
+        return body.greaterOrEqual(other.body)
     }
 }
 

--- a/Sources/StructuralExamples/MyDebugString.swift
+++ b/Sources/StructuralExamples/MyDebugString.swift
@@ -25,12 +25,12 @@ extension StructuralStruct: MyDebugString
 where Properties: MyDebugString {
     public var debugString: String {
         let name: String
-        if let type = self.type {
+        if let type = self.representedType {
             name = String(describing: type)
         } else {
             name = ""
         }
-        return "\(name)(\(properties.debugString))"
+        return "\(name)(\(body.debugString))"
     }
 }
 
@@ -62,12 +62,12 @@ extension StructuralEnum: MyDebugString
 where Cases: MyDebugString {
     public var debugString: String {
         let name: String
-        if let type = self.type {
+        if let type = self.representedType {
             name = String(describing: type)
         } else {
             name = ""
         }
-        return "\(name).\(self.cases.debugString)"
+        return "\(name).\(self.body.debugString)"
     }
 }
 

--- a/Sources/StructuralExamples/MyDecodeJSON.swift
+++ b/Sources/StructuralExamples/MyDecodeJSON.swift
@@ -43,7 +43,7 @@ where Value: MyDecodeJSON, Next: MyDecodeJSON {
 extension StructuralStruct: MyDecodeJSON
 where Properties: MyDecodeJSON {
     public mutating func decodeJson(_ other: Any) {
-        properties.decodeJson(other)
+        body.decodeJson(other)
     }
 }
 

--- a/Sources/StructuralExamples/MyDifferentiable.swift
+++ b/Sources/StructuralExamples/MyDifferentiable.swift
@@ -82,7 +82,7 @@ where Properties: MyDifferentiable {
     typealias TangentVector = Properties.TangentVector
 
     mutating func move(along direction: TangentVector) {
-        self.properties.move(along: direction)
+        self.body.move(along: direction)
     }
 }
 

--- a/Sources/StructuralExamples/MyEncodeJSON.swift
+++ b/Sources/StructuralExamples/MyEncodeJSON.swift
@@ -84,7 +84,7 @@ extension StructuralStruct: MyEncodeJSON
 where Properties: MyEncodeJSON {
     public func encodeJson(into builder: inout JSONBuilder) {
         builder.appendObjectStart()
-        self.properties.encodeJson(into: &builder)
+        self.body.encodeJson(into: &builder)
         builder.appendObjectEnd()
     }
 }

--- a/Sources/StructuralExamples/MyEquatable.swift
+++ b/Sources/StructuralExamples/MyEquatable.swift
@@ -61,14 +61,14 @@ where Value: MyEquatable {
 extension StructuralEnum: MyEquatable
 where Cases: MyEquatable {
     public func myEqual(_ other: Self) -> Bool {
-        cases.myEqual(other.cases)
+        body.myEqual(other.body)
     }
 }
 
 extension StructuralStruct: MyEquatable
 where Properties: MyEquatable {
     public func myEqual(_ other: Self) -> Bool {
-        properties.myEqual(other.properties)
+        body.myEqual(other.body)
     }
 }
 

--- a/Sources/StructuralExamples/MyHashable.swift
+++ b/Sources/StructuralExamples/MyHashable.swift
@@ -73,14 +73,14 @@ where Value: MyHashable {
 extension StructuralEnum: MyHashable
 where Cases: MyHashable {
     public func myHash(into hasher: inout Hasher) {
-        cases.myHash(into: &hasher)
+        body.myHash(into: &hasher)
     }
 }
 
 extension StructuralStruct: MyHashable
 where Properties: MyHashable {
     public func myHash(into hasher: inout Hasher) {
-        properties.myHash(into: &hasher)
+        body.myHash(into: &hasher)
     }
 }
 

--- a/Sources/StructuralExamples/MyInplaceAdd.swift
+++ b/Sources/StructuralExamples/MyInplaceAdd.swift
@@ -33,7 +33,7 @@ where Value: MyInplaceAdd, Next: MyInplaceAdd {
 extension StructuralStruct: MyInplaceAdd
 where Properties: MyInplaceAdd {
     public mutating func inplaceAdd(_ other: Self) {
-        self.properties.inplaceAdd(other.properties)
+        self.body.inplaceAdd(other.body)
     }
 }
 

--- a/Sources/StructuralExamples/MyInplaceScale.swift
+++ b/Sources/StructuralExamples/MyInplaceScale.swift
@@ -66,7 +66,7 @@ where Value: MyInplaceScale, Next: MyInplaceScale {
 extension StructuralStruct: MyInplaceScale
 where Properties: MyInplaceScale {
     public mutating func scale(by scalar: Double) {
-        self.properties.scale(by: scalar)
+        self.body.scale(by: scalar)
     }
 }
 

--- a/Sources/StructuralExamples/PointN.swift
+++ b/Sources/StructuralExamples/PointN.swift
@@ -47,7 +47,7 @@ extension Point1: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
         }
@@ -55,7 +55,7 @@ extension Point1: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
     }
@@ -114,11 +114,11 @@ extension Point2: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
@@ -127,11 +127,11 @@ extension Point2: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
@@ -200,16 +200,16 @@ extension Point3: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
@@ -219,16 +219,16 @@ extension Point3: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
@@ -307,22 +307,22 @@ extension Point4: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -333,22 +333,22 @@ extension Point4: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -437,29 +437,29 @@ extension Point5: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -471,29 +471,29 @@ extension Point5: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -592,29 +592,29 @@ extension Point6: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -622,7 +622,7 @@ extension Point6: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -635,29 +635,29 @@ extension Point6: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -665,7 +665,7 @@ extension Point6: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -774,29 +774,29 @@ extension Point7: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -804,7 +804,7 @@ extension Point7: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -813,7 +813,7 @@ extension Point7: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -827,29 +827,29 @@ extension Point7: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -857,7 +857,7 @@ extension Point7: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -866,7 +866,7 @@ extension Point7: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -985,29 +985,29 @@ extension Point8: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1015,7 +1015,7 @@ extension Point8: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1024,7 +1024,7 @@ extension Point8: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1034,7 +1034,7 @@ extension Point8: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1049,29 +1049,29 @@ extension Point8: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1079,7 +1079,7 @@ extension Point8: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1088,7 +1088,7 @@ extension Point8: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1098,7 +1098,7 @@ extension Point8: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1227,29 +1227,29 @@ extension Point9: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1257,7 +1257,7 @@ extension Point9: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1266,7 +1266,7 @@ extension Point9: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1276,7 +1276,7 @@ extension Point9: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1287,7 +1287,7 @@ extension Point9: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1303,29 +1303,29 @@ extension Point9: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1333,7 +1333,7 @@ extension Point9: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1342,7 +1342,7 @@ extension Point9: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1352,7 +1352,7 @@ extension Point9: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1363,7 +1363,7 @@ extension Point9: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1503,29 +1503,29 @@ extension Point10: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1533,7 +1533,7 @@ extension Point10: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1542,7 +1542,7 @@ extension Point10: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1552,7 +1552,7 @@ extension Point10: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1563,7 +1563,7 @@ extension Point10: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1575,7 +1575,7 @@ extension Point10: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1592,29 +1592,29 @@ extension Point10: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1622,7 +1622,7 @@ extension Point10: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1631,7 +1631,7 @@ extension Point10: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1641,7 +1641,7 @@ extension Point10: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1652,7 +1652,7 @@ extension Point10: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1664,7 +1664,7 @@ extension Point10: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1815,29 +1815,29 @@ extension Point11: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1845,7 +1845,7 @@ extension Point11: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1854,7 +1854,7 @@ extension Point11: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1864,7 +1864,7 @@ extension Point11: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1875,7 +1875,7 @@ extension Point11: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1887,7 +1887,7 @@ extension Point11: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1900,7 +1900,7 @@ extension Point11: Structural {
                 .value
                 .value
             self._11 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -1918,29 +1918,29 @@ extension Point11: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1948,7 +1948,7 @@ extension Point11: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1957,7 +1957,7 @@ extension Point11: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1967,7 +1967,7 @@ extension Point11: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1978,7 +1978,7 @@ extension Point11: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -1990,7 +1990,7 @@ extension Point11: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2003,7 +2003,7 @@ extension Point11: Structural {
             .value
             .value
         self._11 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2165,29 +2165,29 @@ extension Point12: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2195,7 +2195,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2204,7 +2204,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2214,7 +2214,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2225,7 +2225,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2237,7 +2237,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2250,7 +2250,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._11 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2264,7 +2264,7 @@ extension Point12: Structural {
                 .value
                 .value
             self._12 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2283,29 +2283,29 @@ extension Point12: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2313,7 +2313,7 @@ extension Point12: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2322,7 +2322,7 @@ extension Point12: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2332,7 +2332,7 @@ extension Point12: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2343,7 +2343,7 @@ extension Point12: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2355,7 +2355,7 @@ extension Point12: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2368,7 +2368,7 @@ extension Point12: Structural {
             .value
             .value
         self._11 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2382,7 +2382,7 @@ extension Point12: Structural {
             .value
             .value
         self._12 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2555,29 +2555,29 @@ extension Point13: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2585,7 +2585,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2594,7 +2594,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2604,7 +2604,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2615,7 +2615,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2627,7 +2627,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2640,7 +2640,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._11 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2654,7 +2654,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._12 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2669,7 +2669,7 @@ extension Point13: Structural {
                 .value
                 .value
             self._13 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -2689,29 +2689,29 @@ extension Point13: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2719,7 +2719,7 @@ extension Point13: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2728,7 +2728,7 @@ extension Point13: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2738,7 +2738,7 @@ extension Point13: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2749,7 +2749,7 @@ extension Point13: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2761,7 +2761,7 @@ extension Point13: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2774,7 +2774,7 @@ extension Point13: Structural {
             .value
             .value
         self._11 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2788,7 +2788,7 @@ extension Point13: Structural {
             .value
             .value
         self._12 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2803,7 +2803,7 @@ extension Point13: Structural {
             .value
             .value
         self._13 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -2988,29 +2988,29 @@ extension Point14: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3018,7 +3018,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3027,7 +3027,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3037,7 +3037,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3048,7 +3048,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3060,7 +3060,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3073,7 +3073,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._11 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3087,7 +3087,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._12 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3102,7 +3102,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._13 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3118,7 +3118,7 @@ extension Point14: Structural {
                 .value
                 .value
             self._14 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3139,29 +3139,29 @@ extension Point14: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3169,7 +3169,7 @@ extension Point14: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3178,7 +3178,7 @@ extension Point14: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3188,7 +3188,7 @@ extension Point14: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3199,7 +3199,7 @@ extension Point14: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3211,7 +3211,7 @@ extension Point14: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3224,7 +3224,7 @@ extension Point14: Structural {
             .value
             .value
         self._11 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3238,7 +3238,7 @@ extension Point14: Structural {
             .value
             .value
         self._12 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3253,7 +3253,7 @@ extension Point14: Structural {
             .value
             .value
         self._13 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3269,7 +3269,7 @@ extension Point14: Structural {
             .value
             .value
         self._14 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3466,29 +3466,29 @@ extension Point15: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3496,7 +3496,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3505,7 +3505,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3515,7 +3515,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3526,7 +3526,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3538,7 +3538,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3551,7 +3551,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._11 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3565,7 +3565,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._12 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3580,7 +3580,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._13 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3596,7 +3596,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._14 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3613,7 +3613,7 @@ extension Point15: Structural {
                 .value
                 .value
             self._15 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -3635,29 +3635,29 @@ extension Point15: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3665,7 +3665,7 @@ extension Point15: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3674,7 +3674,7 @@ extension Point15: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3684,7 +3684,7 @@ extension Point15: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3695,7 +3695,7 @@ extension Point15: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3707,7 +3707,7 @@ extension Point15: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3720,7 +3720,7 @@ extension Point15: Structural {
             .value
             .value
         self._11 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3734,7 +3734,7 @@ extension Point15: Structural {
             .value
             .value
         self._12 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3749,7 +3749,7 @@ extension Point15: Structural {
             .value
             .value
         self._13 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3765,7 +3765,7 @@ extension Point15: Structural {
             .value
             .value
         self._14 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3782,7 +3782,7 @@ extension Point15: Structural {
             .value
             .value
         self._15 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -3993,29 +3993,29 @@ extension Point16: Structural {
         }
         set {
             self._1 =
-                newValue.properties
+                newValue.body
                 .value
                 .value
             self._2 =
-                newValue.properties
+                newValue.body
                 .next
                 .value
                 .value
             self._3 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .value
                 .value
             self._4 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
                 .value
                 .value
             self._5 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4023,7 +4023,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._6 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4032,7 +4032,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._7 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4042,7 +4042,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._8 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4053,7 +4053,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._9 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4065,7 +4065,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._10 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4078,7 +4078,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._11 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4092,7 +4092,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._12 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4107,7 +4107,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._13 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4123,7 +4123,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._14 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4140,7 +4140,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._15 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4158,7 +4158,7 @@ extension Point16: Structural {
                 .value
                 .value
             self._16 =
-                newValue.properties
+                newValue.body
                 .next
                 .next
                 .next
@@ -4181,29 +4181,29 @@ extension Point16: Structural {
 
     public init(structuralRepresentation: StructuralRepresentation) {
         self._1 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .value
             .value
         self._2 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .value
             .value
         self._3 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .value
             .value
         self._4 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
             .value
             .value
         self._5 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4211,7 +4211,7 @@ extension Point16: Structural {
             .value
             .value
         self._6 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4220,7 +4220,7 @@ extension Point16: Structural {
             .value
             .value
         self._7 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4230,7 +4230,7 @@ extension Point16: Structural {
             .value
             .value
         self._8 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4241,7 +4241,7 @@ extension Point16: Structural {
             .value
             .value
         self._9 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4253,7 +4253,7 @@ extension Point16: Structural {
             .value
             .value
         self._10 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4266,7 +4266,7 @@ extension Point16: Structural {
             .value
             .value
         self._11 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4280,7 +4280,7 @@ extension Point16: Structural {
             .value
             .value
         self._12 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4295,7 +4295,7 @@ extension Point16: Structural {
             .value
             .value
         self._13 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4311,7 +4311,7 @@ extension Point16: Structural {
             .value
             .value
         self._14 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4328,7 +4328,7 @@ extension Point16: Structural {
             .value
             .value
         self._15 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next
@@ -4346,7 +4346,7 @@ extension Point16: Structural {
             .value
             .value
         self._16 =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             .next
             .next
             .next

--- a/Sources/StructuralExamples/PointN.swift.gyb
+++ b/Sources/StructuralExamples/PointN.swift.gyb
@@ -64,7 +64,7 @@ extension Point${N}: Structural {
 	    set {
 	        % for i in range(1, N + 1):
 	        self._${i} =
-                    newValue.properties
+                    newValue.body
 	    	% for j in range(i - 1):
 	    	.next
 	    	% end
@@ -77,7 +77,7 @@ extension Point${N}: Structural {
     public init(structuralRepresentation: StructuralRepresentation) {
         % for i in range(1, N + 1):
         self._${i} =
-            structuralRepresentation.properties
+            structuralRepresentation.body
             % for j in range(i - 1):
             .next
             % end

--- a/Sources/StructuralExamples/Semester.swift
+++ b/Sources/StructuralExamples/Semester.swift
@@ -56,14 +56,14 @@ extension Semester: Structural {
                         StructuralEmpty())))
             classes = []
             // Use swap to avoid copies.
-            defer { swap(&av.properties.next.value.value, &classes) }
+            defer { swap(&av.body.next.value.value, &classes) }
             yield &av
         }
     }
 
     public init(structuralRepresentation: StructuralRepresentation) {
-        self.year = structuralRepresentation.properties.value.value
-        self.classes = structuralRepresentation.properties.next.value.value
+        self.year = structuralRepresentation.body.value.value
+        self.classes = structuralRepresentation.body.next.value.value
     }
 }
 

--- a/Sources/StructuralExamples/StudentGrade.swift
+++ b/Sources/StructuralExamples/StudentGrade.swift
@@ -57,15 +57,15 @@ extension StudentGrades: Structural {
 
             // Use swap to avoid copies.
             grades = []
-            defer { swap(&av.properties.next.value.value, &grades) }
+            defer { swap(&av.body.next.value.value, &grades) }
 
             yield &av
         }
     }
 
     public init(structuralRepresentation: StructuralRepresentation) {
-        self.classId = structuralRepresentation.properties.value.value
-        self.grades = structuralRepresentation.properties.next.value.value
+        self.classId = structuralRepresentation.body.value.value
+        self.grades = structuralRepresentation.body.next.value.value
     }
 }
 

--- a/Tests/StructuralTests/MyDifferentiableTests.swift
+++ b/Tests/StructuralTests/MyDifferentiableTests.swift
@@ -57,14 +57,14 @@ extension LabeledPoint3: Structural {
             )
 	    }
 	    set {
-	        self.label = newValue.properties.value.value.wrappedValue
-	        self.value = newValue.properties.next.value.value
+	        self.label = newValue.body.value.value.wrappedValue
+	        self.value = newValue.body.next.value.value
 	    }
     }
 
     public init(structuralRepresentation: StructuralRepresentation) {
-        self.label = structuralRepresentation.properties.value.value.wrappedValue
-        self.value = structuralRepresentation.properties.next.value.value
+        self.label = structuralRepresentation.body.value.value.wrappedValue
+        self.value = structuralRepresentation.body.next.value.value
     }
 }
 


### PR DESCRIPTION
Add doc comments for:
- `Structural` protocol
- `StructuralStruct`, `StructuralProperty`
- `StructuralEnum`, `StructuralCase`
- `StructuralCons`, `StructuralEmpty`, `StructuralEither`

Rename properties:
- `StructuralStruct.type` -> `StructuralStruct.representedType`
- `StructuralStruct.properties` -> `StructuralStruct.body`
- `StructuralEnum.type` -> `StructuralEnum.representedType`
- `StructuralEnum.cases` -> `StructuralEnum.body`

---

Documentation changes were discussed during Swift for TensorFlow team meeting.
There's further room for improvement, we can discuss on this PR.